### PR TITLE
doc: Added missing MicroK8s tab in the tab-block + other fixes

### DIFF
--- a/docs/setup/install/Install-devtron-on-Minikube-Microk8s-K3s-Kind.md
+++ b/docs/setup/install/Install-devtron-on-Minikube-Microk8s-K3s-Kind.md
@@ -1,6 +1,6 @@
 # Install Devtron on Minikube, Microk8s, K3s, Kind, Cloud VMs
 
-You can install and try Devtron on a high-end machine or a Cloud VM. If you install it on a laptop/PC, it may start to respond slowly, so it is recommended to uninstall Devtron from your system before shutting it down.
+You can install and try Devtron on a high-end machine or a Cloud VM. If you install it on a laptop/PC, it may start to respond slowly.
 
 ## Prerequisites
 
@@ -8,9 +8,9 @@ You can install and try Devtron on a high-end machine or a Cloud VM. If you inst
 2. 4GB+ of free memory
 3. 20GB+ free disk space
 
-Before you get started, you must set up a cluster in your server and finish the following actions:
+Before you get started, finish the following actions:
 
- * Create a cluster using [Minikube](https://minikube.sigs.k8s.io/docs/start/) or [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/) or [K3s](https://rancher.com/docs/k3s/latest/en/installation/).
+ * Create a cluster using [Minikube](https://minikube.sigs.k8s.io/docs/start/) or [MicroK8s](https://microk8s.io/docs/tutorials) or [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/) or [K3s](https://rancher.com/docs/k3s/latest/en/installation/).
  * Install [Helm3](https://helm.sh/docs/intro/install/).
  * Install [kubectl](https://kubernetes.io/docs/tasks/tools/).
 
@@ -22,13 +22,13 @@ Before you get started, you must set up a cluster in your server and finish the 
 
 ---
 
-## For Minikube, Microk8s, K3s, Kind
+## For Minikube, MicroK8s, Kind, K3s
 
 {% tabs %}
 
-{% tab title=" Minikube/Kind Cluster" %}
+{% tab title=" Minikube/MicroK8s/Kind Cluster" %}
 
- To install devtron on ``Minikube/kind`` cluster, run the following command:
+ To install Devtron on **Minikube/MicroK8s/Kind** cluster, run the following command:
 
 ```bash
 helm repo add devtron https://helm.devtron.ai
@@ -42,8 +42,8 @@ helm install devtron devtron/devtron-operator \
 ```
 {% endtab %}
 
-{% tab title="k3s Cluster" %}
-To install devtron on ``k3s`` cluster, run the following command:
+{% tab title="K3s Cluster" %}
+To install Devtron on **K3s** cluster, run the following command:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
@@ -63,23 +63,34 @@ helm install devtron devtron/devtron-operator \
  
 ### Access Devtron Dashboard
 
-To access Devtron dashboard when using ``Minikube`` as cluster, run the following command:
+{% tabs %}
+{% tab title="Minikube" %}
+
+To access the dashboard on **Minikube** cluster, run the following command:
 
 ```bash
 minikube service devtron-service --namespace devtroncd
 ```
 
-To access Devtron dashboard when using ``Kind/k3s`` as cluster, run the following command to port forward the devtron service to port 8000:
+This will directly open the dashboard URL in your browser
+
+{% endtab %}
+{% tab title="MicroK8s/Kind/K3s Cluster" %}
+
+To access the dashboard on **MicroK8s/Kind/K3s** cluster, run the following command to port-forward the devtron service to port 8000:
 
 ```bash
 kubectl -n devtroncd port-forward service/devtron-service 8000:80
 ```
 
-**Dashboard**: [http://127.0.0.1:8000](http://127.0.0.1:8000).
+After port-forwarding, you can access the dashboard at this URL: [http://127.0.0.1:8000](http://127.0.0.1:8000)
+
+{% endtab %}
+{% endtabs %}
 
 ### Get Admin Credentials
 
-When you install Devtron for the first time, it creates a default admin user and password (with unrestricted access to Devtron). You can use that credentials to log in as an administrator. 
+When you install Devtron for the first time, it creates a default admin user and password (with unrestricted access to Devtron). You can use those credentials to log in as an administrator. 
 
 After the initial login, we recommend you set up any SSO service like Google, GitHub, etc., and then add other users (including yourself). Subsequently, all the users can use the same SSO (let's say, GitHub) to log in to Devtron's dashboard.
 
@@ -114,7 +125,7 @@ kubectl -n devtroncd get secret devtron-secret \
 
 It is recommended to use Cloud VM with 2vCPU+, 4GB+ free memory, 20GB+ storage, Compute Optimized VM type & Ubuntu Flavoured OS.
 
-### Create Microk8s Cluster
+### Create MicroK8s Cluster
 
 ```bash
 sudo snap install microk8s --classic --channel=1.22
@@ -145,10 +156,10 @@ helm install devtron devtron/devtron-operator \
 kubectl get svc -n devtroncd devtron-service -o jsonpath='{.spec.ports[0].nodePort}'
 ```
 
-Make sure that the port on which the devtron-service runs remain open in the VM's security group or network security group.
+Make sure that the port used by the devtron-service remain open in the VM's security group or network security group.
 
 {% hint style="info" %}
-If you want to uninstall Devtron or clean Devtron helm installer, refer our [uninstall Devtron](./uninstall-devtron.md).
+If you want to uninstall Devtron or clean up the Devtron Helm installer, refer [uninstall Devtron](./uninstall-devtron.md).
 {% endhint %}
 
-If you have questions, please let us know on our discord channel. [![Join Discord](https://img.shields.io/badge/Join%20us%20on-Discord-e01563.svg)](https://discord.gg/jsRG5qx2gp)
+If you have questions, please let us know on our Discord channel. [![Join Discord](https://img.shields.io/badge/Join%20us%20on-Discord-e01563.svg)](https://discord.gg/jsRG5qx2gp)


### PR DESCRIPTION
Current doc has MicroK8s block missing
<img width="814" alt="image" src="https://github.com/user-attachments/assets/7a69135b-ce64-4869-b203-7bee9b735c5a" />