### PR TITLE
docs: Fixed Invalid YAML in Image Promotion Doc

### DIFF
--- a/docs/user-guide/global-configurations/image-promotion-policy.md
+++ b/docs/user-guide/global-configurations/image-promotion-policy.md
@@ -153,15 +153,16 @@ You can apply a policy using our APIs or through Devtron CLI. Here is the CLI ap
 apiVersion: v1
 kind: artifactPromotionPolicy
 spec:
-    payload:
+  payload:
     applicationEnvironments:
-    - appName: "app1"
+      - appName: "app1"
         envName: "env-demo"
-    - appName: "app1"
+      - appName: "app1"
         envName: "env-staging"
-    - appName: "app2"
+      - appName: "app2"
         envName: "env-demo"
-    applyToPolicyName: "example-policy"
+    applyToPolicyNames:
+      - "example-policy"
 ```
 {% endcode %}
 


### PR DESCRIPTION
**Indentation issue with this YAML**

<img width="766" alt="image" src="https://github.com/user-attachments/assets/e1e887b3-db82-4f64-ba7f-6411f6ba9b30" />