### PR TITLE
fix: Removed --channel from microk8s command

### DIFF
--- a/docs/setup/install/Install-devtron-on-Minikube-Microk8s-K3s-Kind.md
+++ b/docs/setup/install/Install-devtron-on-Minikube-Microk8s-K3s-Kind.md
@@ -133,7 +133,7 @@ It is recommended to use Cloud VM with 2vCPU+, 4GB+ free memory, 20GB+ storage, 
 ### Create MicroK8s Cluster
 
 ```bash
-sudo snap install microk8s --classic --channel=1.22
+sudo snap install microk8s --classic 
 sudo usermod -a -G microk8s $USER
 sudo chown -f -R $USER ~/.kube
 newgrp microk8s


### PR DESCRIPTION
--channel specifies which k8s you would like to run microk8s on, as it was set to 1.22 the microk8s would run on k8s 1.22 and an older version of helm.

Removing this, microk8s defaults to the latest stable k8s version