### PR TITLE
misc: Tentative removal of old YouTube links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Devtron deeply integrates with products across the lifecycle of microservices i.
 Devtron helps you to deploy, observe, manage & debug the existing Helm apps in all your clusters.
  
  
-{% embed url="https://www.youtube.com/watch?v=AG8HfTceHxw" caption="Introducing Devtron" %}
+<!-- {% embed url="https://www.youtube.com/watch?v=AG8HfTceHxw" caption="Introducing Devtron" %} -->
  
  
 ## Devtron's Key Features:

--- a/docs/user-guide/Deploy-sample-app/nodejs_app.md
+++ b/docs/user-guide/Deploy-sample-app/nodejs_app.md
@@ -3,7 +3,7 @@
 Hurray! 
 Your Devtron stack is completely setup. Let's get started by deploying a simple application on it.
 
-{% embed url="https://www.youtube.com/watch?v=9u-pKiWV-tM&t=2s" caption="Deploy a Kubernetes Node.js micro-service using Devtron" %}
+<!-- {% embed url="https://www.youtube.com/watch?v=9u-pKiWV-tM&t=2s" caption="Deploy a Kubernetes Node.js micro-service using Devtron" %} -->
 
 ## Find out the steps here 
 

--- a/docs/user-guide/creating-application/README.md
+++ b/docs/user-guide/creating-application/README.md
@@ -2,7 +2,7 @@
 
 **Please configure Global Configurations before moving ahead with App Configuration**
 
-{% embed url="https://www.youtube.com/watch?v=9u-pKiWV-tM" caption="" %}
+<!-- {% embed url="https://www.youtube.com/watch?v=9u-pKiWV-tM" caption="" %} -->
 
 **Parts of Documentation**
 


### PR DESCRIPTION
Old YouTube channel has been erroneously deleted. So until it is restored, we will be hiding the old YT videos to avoid inconvenience to the readers.