### PR TITLE
doc: Version banner improvement

### DIFF
--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import clsx from 'clsx';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import {
+  useActivePlugin,
+  useDocVersionSuggestions,
+} from '@docusaurus/plugin-content-docs/client';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {
+  useDocsPreferredVersion,
+  useDocsVersion,
+} from '@docusaurus/plugin-content-docs/client';
+
+function UnreleasedVersionLabel({siteTitle, versionMetadata}) {
+  return (
+    <Translate
+      id="theme.docs.versions.unreleasedVersionLabel.custom"
+      description="Label shown when the user is browsing an unreleased doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}>
+      {
+        'This page is part of unreleased documentation for {siteTitle} {versionLabel}. Content here may change before the official release.'
+      }
+    </Translate>
+  );
+}
+
+function UnmaintainedVersionLabel({siteTitle, versionMetadata}) {
+  return (
+    <Translate
+      id="theme.docs.versions.unmaintainedVersionLabel.custom"
+      description="Label shown when the user is browsing an older unmaintained doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}>
+      {
+        'You are viewing documentation for an older Devtron release ({versionLabel}).'
+      }
+    </Translate>
+  );
+}
+
+const BannerLabelComponents = {
+  unreleased: UnreleasedVersionLabel,
+  unmaintained: UnmaintainedVersionLabel,
+};
+
+function BannerLabel(props) {
+  const BannerLabelComponent =
+    BannerLabelComponents[props.versionMetadata.banner];
+  return <BannerLabelComponent {...props} />;
+}
+
+function LatestVersionSuggestionLabel({versionLabel, to, onClick}) {
+  return (
+    <Translate
+      id="theme.docs.versions.latestVersionSuggestionLabel.custom"
+      description="Label encouraging the user to check the latest stable docs"
+      values={{
+        versionLabel,
+        latestVersionLink: (
+          <b>
+            <Link to={to} onClick={onClick}>
+              <Translate
+                id="theme.docs.versions.latestVersionLinkLabel.custom"
+                description="Link text for the latest version suggestion">
+                latest version
+              </Translate>
+            </Link>
+          </b>
+        ),
+      }}>
+      {
+        'Check the {latestVersionLink} ({versionLabel}).'
+      }
+    </Translate>
+  );
+}
+
+function DocVersionBannerEnabled({className, versionMetadata}) {
+  const {
+    siteConfig: {title: siteTitle},
+  } = useDocusaurusContext();
+  const {pluginId} = useActivePlugin({failfast: true});
+  const getVersionMainDoc = (version) =>
+    version.docs.find((doc) => doc.id === version.mainDocId);
+  const {savePreferredVersionName} = useDocsPreferredVersion(pluginId);
+  const {latestDocSuggestion, latestVersionSuggestion} =
+    useDocVersionSuggestions(pluginId);
+
+  const latestVersionSuggestedDoc =
+    latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        'alert alert--warning margin-bottom--md',
+      )}
+      role="alert">
+
+      {/* One-line banner */}
+      <span style={{ whiteSpace: 'nowrap' }}>
+        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />{' '}
+        <LatestVersionSuggestionLabel
+          versionLabel={latestVersionSuggestion.label}
+          to={latestVersionSuggestedDoc.path}
+          onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+        />
+      </span>
+
+    </div>
+  );
+}
+
+
+export default function DocVersionBanner({className}) {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata && versionMetadata.banner) {
+    return (
+      <DocVersionBannerEnabled
+        className={className}
+        versionMetadata={versionMetadata}
+      />
+    );
+  }
+  return null;
+}

--- a/src/theme/DocVersionBanner/styles.module.css
+++ b/src/theme/DocVersionBanner/styles.module.css
@@ -1,0 +1,34 @@
+.banner {
+    background: linear-gradient(180deg, #fff6e6 0%, #fff3d9 100%);
+    border: 1px solid #f0d9a8;
+    padding: 12px 18px;
+    border-radius: 8px;
+    margin: 12px 0;
+    box-shadow: 0 1px 0 rgba(0,0,0,0.03);
+    font-size: 15px;
+  }
+  
+  .inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  
+  .text {
+    color: #5b4218;
+  }
+  
+  .actions {
+    flex-shrink: 0;
+  }
+  
+  .cta {
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: white;
+    border: 1px solid #e6c88a;
+    text-decoration: none;
+    font-weight: 600;
+  }
+  


### PR DESCRIPTION
The below banner for older doc version led people to believe that the earlier version of product is no longer maintained thus causing confusion.

<img width="1431" height="451" alt="image" src="https://github.com/user-attachments/assets/93a14e79-b49e-4c86-8c2a-b687d0320a27" />

The messaging has been changed to this: 

<img width="1431" height="361" alt="image" src="https://github.com/user-attachments/assets/c60aad2c-a8c2-4fb1-a4f2-2de0860078ed" />

