### PR TITLE
docs: Enhance application documentation with persistent filters and environment filtering details

### DIFF
--- a/docs/user-guide/app-details/application-summary.md
+++ b/docs/user-guide/app-details/application-summary.md
@@ -32,6 +32,17 @@ The icon next to the **Env** drop-down box denotes the application deployment me
 Manifest status (whether they are in sync or not) is denoted by [this](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/devtron-v2/app-management/devtron-apps/app-details/app-summary/manifest-status-icon.jpg) icon. When you click on this icon, the **Live and desired manifest comparison** page is displayed (read-only) allowing you to compare the manifests and view config drifts (if there are any). 
 
 ---
+## Filtering Environments
+
+If your application is deployed to several environments, you can narrow down the ones you want to focus on using the environment filter available in the **page header**. This filter is present across all the application pages, including **Overview**, **App Details**, **Build & Deploy**, **Build History**, **Deployment History**, **Deployment Metrics**, and **Configurations**.
+
+Open the filter and multi-select the environments you care about. The application then shows only the selected environments wherever the environment list appears, helping you cut through the noise when an application spans many environments.
+
+:::info Persistent selection
+Your environment selection is saved in your browser's local storage on a per-application basis. The next time you open the same application, Devtron automatically restores the environments you had selected, so you don't have to filter them again.
+:::
+
+---
 ## Cards Overview
 
 Devtron provides you a quick summary of your application via cards. Refer to the following table to know more about cards:

--- a/docs/user-guide/application-groups.md
+++ b/docs/user-guide/application-groups.md
@@ -442,7 +442,11 @@ Assume you have multiple applications (maybe 10, 50, 100, or more) showing up in
     ![](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/devtron-v2/app-management/application-groups/app-filter-3.jpg)
     <center>Figure 46: Filtered Apps</center>
 
-4. (Optional) If required, you can save the filter for future use by clicking **Save selection as filter**.
+    :::info Persistent selection
+    Your filter selection is remembered for each application group. When you reopen the group, Devtron automatically reapplies the applications you had filtered, so you don't have to reselect them every time.
+    :::
+
+4. (Optional) If required, you can save the filter for future use as a named selection by clicking **Save selection as filter**. A saved filter lets you select or deselect an entire group of applications in one click whenever you need it.
 
     ![](https://devtron-public-asset.s3.us-east-2.amazonaws.com/images/devtron-v2/app-management/application-groups/save-filter.jpg)
     <center>Figure 47: Saving a Filter</center>

--- a/docs/user-guide/applications.md
+++ b/docs/user-guide/applications.md
@@ -34,6 +34,24 @@ You can use this to:
 ### Other Options
 
 There are additional options available for you:
-* **Search and filters** to make it easier for you to find applications.
+* **Search and filters** to make it easier for you to find applications. Refer to [Searching and Filtering](#searching-and-filtering) for more information.
 * **Export CSV** to download the data of Devtron apps (not supported for Helm apps and Argo CD apps).
 * **Sync button** to refresh the app listing.
+
+### Searching and Filtering
+
+To help you quickly find the applications you need, the **Applications** page provides a search bar along with a set of filters (such as app status, project, environment, cluster, and namespace).
+
+Click **Filters** to open the filter dropdown and select the values you want to filter by. The application list updates to show only the applications matching your selection.
+
+:::tip Keyboard shortcut
+Press the `f` key anywhere on the **Applications** page to open the filter dropdown without using your mouse.
+:::
+
+#### Persistent Filters
+
+Devtron remembers the filters you apply on the **Applications** page. The next time you return to the page — even after refreshing the page or signing in again in a new session — your previously applied filters are automatically reapplied, so you can pick up right where you left off.
+
+:::info Note
+Filtering by application **tags** is the only filter that is **not** persisted. Every other filter from the dropdown is remembered.
+:::


### PR DESCRIPTION
This pull request updates the user documentation to clarify and highlight the persistent filter and environment selection features across the Devtron UI. The main focus is on improving user experience by explaining how filter selections are remembered and automatically restored, making navigation and management of applications and environments more efficient.

Persistent filtering and selection improvements:

* Added a new section in `application-summary.md` describing the environment filter available in the page header, its multi-select capability, and how selections are saved per application in local storage for automatic restoration.
* Updated `application-groups.md` to explain that application group filter selections are now remembered and automatically reapplied when reopening a group, and clarified the difference between persistent filters and named saved filters.
* Expanded the `applications.md` documentation to detail the search and filter functionality, including a keyboard shortcut, and added a section on persistent filters, specifying that all filters except tag filters are remembered across sessions.